### PR TITLE
File explorer: rename/delete UI and file icons

### DIFF
--- a/src/lib/components/FileTreeNode.svelte
+++ b/src/lib/components/FileTreeNode.svelte
@@ -7,6 +7,7 @@
   let expanded = $state(false);
   let contextMenu = $state<{ x: number; y: number } | null>(null);
   let renaming = $state(false);
+  let renameCancelled = false;
   let renameValue = $state("");
   let renameInput: HTMLInputElement | undefined;
 
@@ -46,12 +47,21 @@
   function startRename() {
     contextMenu = null;
     renameValue = entry.name;
+    renameCancelled = false;
     renaming = true;
-    // Focus the input after it renders
-    setTimeout(() => renameInput?.focus(), 0);
+    setTimeout(() => {
+      renameInput?.focus();
+      // Select filename without extension for convenience
+      const dotIdx = renameValue.lastIndexOf(".");
+      renameInput?.setSelectionRange(0, dotIdx > 0 ? dotIdx : renameValue.length);
+    }, 0);
   }
 
   async function commitRename() {
+    if (!renaming || renameCancelled) {
+      renaming = false;
+      return;
+    }
     renaming = false;
     const newName = renameValue.trim();
     if (!newName || newName === entry.name) return;
@@ -64,7 +74,10 @@
 
   function handleRenameKeydown(e: KeyboardEvent) {
     if (e.key === "Enter") commitRename();
-    if (e.key === "Escape") { renaming = false; }
+    if (e.key === "Escape") {
+      renameCancelled = true;
+      renaming = false;
+    }
   }
 
   async function handleDelete() {

--- a/src/lib/stores/vault.svelte.ts
+++ b/src/lib/stores/vault.svelte.ts
@@ -147,11 +147,9 @@ class VaultStore {
   }
 
   private handleFsChange(payload: { kind: string; paths: string[] }) {
-    // Accumulate events during debounce window
+    // Accumulate all events during debounce window
     for (const p of payload.paths) {
-      if (p.endsWith(".md") || p.endsWith(".markdown")) {
-        this.fsPendingPaths.add(p);
-      }
+      this.fsPendingPaths.add(p);
     }
     this.fsPendingKinds.add(payload.kind);
 
@@ -160,17 +158,24 @@ class VaultStore {
   }
 
   private async processFsChanges() {
-    const paths = [...this.fsPendingPaths];
+    const allPaths = [...this.fsPendingPaths];
     const kinds = [...this.fsPendingKinds];
     this.fsPendingPaths.clear();
     this.fsPendingKinds.clear();
 
-    if (paths.length === 0 && !kinds.some((k) => k === "create" || k === "remove")) return;
+    if (allPaths.length === 0) return;
 
-    console.log("[vault] fs-change:", kinds.join(","), paths.length, "markdown files");
+    const mdPaths = allPaths.filter(
+      (p) => p.endsWith(".md") || p.endsWith(".markdown"),
+    );
 
-    // Always refresh tree — Windows fires modify instead of create sometimes
+    console.log("[vault] fs-change:", kinds.join(","), allPaths.length, "paths,", mdPaths.length, "markdown");
+
+    // Always refresh tree — folder creates/renames/deletes matter too
     await this.refreshTree();
+
+    // Only re-index markdown files
+    const paths = mdPaths;
 
     // Re-index changed files
     const hasRemove = kinds.includes("remove");


### PR DESCRIPTION
## Summary
- **Context menu**: Right-click any file/folder for Rename and Delete options
- **Inline rename**: Editable text field, Enter to confirm, Escape to cancel
- **Delete with confirmation**: Prompt before deleting, removes from tree and indexes
- **File icons**: 📂/📁 folders, 📝 markdown, 🖼️ images, 📄 other files

## Test plan
- [ ] Right-click a file → context menu appears with Rename and Delete
- [ ] Click Rename → inline edit field, type new name, press Enter → file renamed
- [ ] Press Escape during rename → cancels
- [ ] Click Delete → confirmation dialog → file removed from tree
- [ ] Deleting an open file closes its tab
- [ ] File icons show correctly for .md, folders, images, and other files
- [ ] Renaming an open file updates the tab name

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)