### PR TITLE
Docs: session status for v0.3.0 release

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,7 +1,7 @@
 # Project Status
 
-**Last updated**: 2026-08-11
-**Release**: v0.2.0 (user-tested and approved; see CHANGELOG.md)
+**Last updated**: 2026-08-12
+**Release**: v0.3.0 tagged (release workflow running as of this update — first tag build with whisper.cpp + xcap; draft release needs review + Publish when it finishes; downloads page then updates itself)
 
 ## Current State
 Phases 1-9 complete; Phase 10 (Plugin System) not started. v0.2.0 shipped the July 2026 wave (user-tested 2026-07-18):
@@ -109,9 +109,20 @@ Four rounds of user desktop testing of #47/#48. **User confirmed all tests pass 
 - Round 4 (#49 root-caused — it was NOT the stale installed build): Editor-creation $effect tracked `livePreview` → every view-mode switch rebuilt CM from file-open-time content = silent edit loss (untrack fix + component regression test). Live preview: images render (ImageWidget + resolveImage), empty `- [ ]` tasks get checkboxes, prose font, hidden fences + shaded code blocks, focus-aware reveal (unfocused = fully rendered), frontmatter as dimmed metadata. New palette command "Transcribe in this note" (enableTranscription adds frontmatter to any note). README view-mode/toolbar docs fixed
 - Tests: 107 vitest + 29 cargo green. `/attachments/` + `/daily/` gitignored (repo doubles as user vault)
 
+## Recent Work (2026-08-12, icon + zoom + follow + release session)
+All user-tested on desktop, merged to main via PRs #60/#61/#62/#63:
+- #54 app icon: MD monogram w/ cyan down-arrow D-stem; vector master `src-tauri/app-icon.svg` (user-refined in Illustrator); full icon set regenerated; RELEASING.md documents SVG as source of truth
+- #56 UI zoom: Ctrl+Scroll / Ctrl+= / Ctrl+- / Ctrl+0 + Settings → Display slider (50–200%), persisted `uiZoom`; native WebView2 setZoom (capability `core:webview:allow-set-webview-zoom`), CSS `--ui-zoom` fallback in browser mode; ZoomIndicator badge; graph exempt via `data-zoom-exempt`; sticky/capture windows deliberately 100% (crop math)
+- #59 transcript follow: pins to bottom on pure appends at doc end during a session (direct scrollTop pin — CM scrollIntoView undershoots on estimated line heights, do NOT revert to it); upward-scroll-only break detection; "⤓ Scroll to end" resumes; `{#key file.path}` on TranscriptionBar fixed mid-session retargeting bug
+- Stickies keep their pop-out theme — accidental behavior promoted to documented feature (screenshot: tasks/.user-screenshots/thisisafeaturenotabug.png); restart persistence is #58
+- #55 release v0.3.0: versions bumped, CHANGELOG written, local Windows bundles verified (MSI+NSIS, ~8MB with whisper), tag pushed
+- Tests: 132 vitest + 29 cargo
+- New backlog: #57 per-theme font scale (`--theme-font-scale` mechanism sketched in issue), #58 per-sticky theme persistence
+
 ## Open Issues
 - #21 — Cloud sync via Git/GitHub (future feature; data model prepared, see docs/COLLABORATION.md)
 - #43 — Code signing + notarization for release builds (workflow wired; awaiting Azure/Apple credentials, see docs/SIGNING.md)
 - #46 — Accessibility audit of the app (screen reader support)
-- #54 — New app icon (user candidates in `tasks/.user-logo-options/`, gitignored) — NEXT
-- #55 — Release v0.3.0 after the icon lands
+- #55 — Release v0.3.0 (tag pushed; close after draft release is published)
+- #57 — Per-theme default font scale (user wants to hand-tune values)
+- #58 — Make per-sticky themes restart-proof

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,33 +1,12 @@
 # Session scratchpad
 
-## Current: #54 icon + #56 zoom + #59 follow awaiting user test → then #55 release v0.3.0
+## Current: v0.3.0 release workflow running
 
-#59 transcript follow (2026-08-12): `issue-59-transcript-follow` (stacked on 56).
-transcriptFollow store + isPureAppend + editorBridge.scrollToEnd + direct
-scrollTop pin (CM scrollIntoView undershoots on estimated heights — do NOT
-"simplify" back to it) + direction-based break (upward scroll only).
-{#key file.path} on TranscriptionBar fixes session-retargeting bug.
-132 vitest green (10 new); flow verified in prod-build mock mode on :5599.
-Backlog issues filed this session: #57 per-theme font scale, #58 sticky themes.
-Merge order: PR #54 → #56 → #59 → then #55 release.
+- #54/#56/#59 merged (PRs #60/#61/#62), #63 = version bump. Tag v0.3.0 pushed 2026-08-12 ~15:20 EDT.
+- Release run 31632127527 — FIRST tag build with whisper.cpp + xcap on Linux/macOS legs.
+  Windows leg de-risked by a successful local `npm run tauri build` (MSI + NSIS produced).
+- When it finishes: review the DRAFT release on GitHub (artifacts + notes), Publish, close #55.
+  Downloads page self-updates after publish — do NOT redeploy it.
+- If a leg fails: likely missing system dep on the runner; fix in release.yml, delete+re-push tag.
 
-#56 UI zoom (2026-08-12): built on `issue-56-ui-zoom` (stacked on issue-54).
-Native setZoom + CSS dev fallback, settings.uiZoom, ZoomIndicator badge,
-Display slider, graph exempt, capability `core:webview:allow-set-webview-zoom`.
-122 vitest green (15 new); build compiles; mock-mode flow browser-verified.
-User's dev server (running since 11:12) needs full restart — branch churn
-under it + capability/icon are build-time. Handoff in tasks/user.md.
-Merge order after approval: PR #54 → PR #56 → #55 release.
-
-Done this session (2026-08-12):
-- User picked the MD-monogram-with-down-arrow concept (midnight + cyan)
-- Authored vector master `src-tauri/app-icon.svg` (pure paths, no font deps)
-- Regenerated all of `src-tauri/icons/` via `npm run tauri icon src-tauri/app-icon.svg`
-- RELEASING.md icon section updated (SVG is the source of truth now)
-- Branch `issue-54-app-icon`, committed, NOT pushed — awaiting user test (tasks/user.md)
-
-Next after user approves icon:
-- Push branch, PR, merge, close #54
-- #55 release v0.3.0: CHANGELOG entry, bump versions (package.json, tauri.conf.json,
-  Cargo.toml), tag per RELEASING.md, WATCH the release CI — first tag build with
-  whisper.cpp + xcap on the Linux/macOS legs (unproven; unsigned, #43 on hold)
+Backlog next: #57 per-theme font scale, #58 sticky theme persistence, #43 signing (on hold), #46 a11y, #21 sync.

--- a/tasks/user.md
+++ b/tasks/user.md
@@ -1,54 +1,16 @@
-# Handoff: Test #54 new app icon + #56 UI zoom + #59 transcript follow
+# Handoff: v0.3.0 releasing
 
-## ⚠️ Restart `cargo tauri dev` (again — sorry)
-Follow mode (#59) added a brand-new store module to a running dev server — the exact condition that caused July's "two store instances, clicks do nothing" bug. A webview Ctrl+R is NOT enough; quit the app, stop the server, `git status` should say `issue-59-transcript-follow`, then `cargo tauri dev`.
+Everything you tested today is merged and released to main: app icon (#54), UI zoom (#56), transcript follow (#59). Tag `v0.3.0` is pushed and the release workflow is building installers for Windows/macOS/Linux — the first release build that compiles whisper.cpp and xcap on all three platforms.
 
-### Transcript follow (#59) — new since your last restart
-1. Open/create a transcription note, Listen, play something with speech.
-2. As lines land, the editor should stick to the bottom (terminal-style).
-3. Scroll UP mid-session → view stays where you put it; a **⤓ Scroll to end** button appears in the recorder bar.
-4. Click it → jumps to the newest lines and follows again.
-5. Edit a paragraph higher up while un-tracked → appends must not move your cursor or scroll.
-6. Known wrinkle: while an italic partial line is showing in the bar, the newest final can sit just below the fold for a few seconds until the next line lands.
-7. Behavior change: switching to a *different* transcription note mid-session now STOPS the session (it used to silently keep recording into the new note).
-Verified by me end-to-end in mock mode (follow, break, stay-put, resume, stop); real-audio pass is yours.
+## What's left (mostly me, watching CI)
+1. Release run finishes → I review the draft release → you (or I, say the word) click **Publish**.
+2. After publish, https://paperhurts.github.io/doc-md/ shows v0.3.0 automatically — no redeploy.
+3. Installers are still unsigned (#43 on hold) — SmartScreen will warn on first install, as with v0.2.0.
 
----
+## For you, once published
+- Install v0.3.0 over your v0.2.0 desktop install — your Start-menu shortcut finally gets the new MD icon and all the capture/zoom/follow features outside the dev tree.
+- Your vault/notes are untouched by upgrades (they're just files in your repo).
 
-**Context if you've been AFK:** Two things landed today, both unpushed, stacked on one branch so a single dev run tests both:
-- **#54 app icon** — your Illustrator-refined MD-with-down-arrow SVG (`src-tauri/app-icon.svg`); all platform icons regenerated from it. I zoom-inspected the render: the corner speck you circled is gone, edges are clean.
-- **#56 UI zoom** — browser-style whole-app zoom because theme fonts (Cyberpunk etc.) run small on your monitor. Ctrl+MouseWheel, Ctrl+= / Ctrl+- / Ctrl+0, a Settings → Display slider, and a brief % badge bottom-right. Persists across restarts. Uses native WebView2 zoom, so text stays crisp; sticky notes and the screenshot overlay deliberately stay at 100% (zooming the overlay would corrupt crop math).
-
-Already verified by me: 122 vitest green (15 new), production build compiles, and the full zoom flow (keys, wheel, badge, persistence, AltGr guard) works in browser mock mode. What mock mode can't prove — native zoom in the real webview, CM6 cursor accuracy while zoomed, capture isolation — is yours below.
-
-## ⚠️ RESTART REQUIRED FIRST
-Your dev server from ~11:12 AM is still running. I switched branches (main → issue-54 → issue-56) and edited files underneath it, so its module graph is stale (the "works on fresh server, silently broken on old one" failure mode from July). Also, the new icon and a Tauri capability change only load at build time. **Quit the app AND stop `cargo tauri dev`, then:**
-
-```
-cd C:\dev\doc-md
-git status        # should say issue-56-ui-zoom
-cargo tauri dev
-```
-
-## How to test
-
-### Icon (#54)
-1. Check the MD-arrow icon in: title bar/taskbar, system tray (smallest render — should still read "MD"), and Alt+Tab.
-2. The installed v0.2.0 desktop shortcut keeping the OLD icon is expected until v0.3.0 ships.
-
-### UI zoom (#56)
-3. **Ctrl+=** three times → UI grows 110/120/130%, badge shows the % bottom-right and fades ~1.2 s after you stop. **Ctrl+-** steps back. **Ctrl+0** → 100%. Holding Ctrl+= keeps zooming and stops at 200%.
-4. **Ctrl+MouseWheel** over the editor, file tree, and preview → zooms; the page must NOT scroll while Ctrl is held. Text should stay crisp, not blurry-scaled.
-5. At 150%: click around in the editor — the caret must land exactly where you click; `[[` autocomplete popups must align; Ctrl+K palette and Settings modal must still cover the window.
-6. Graph view (Ctrl+Shift+G): Ctrl+wheel over the graph zooms the **graph** (as before); close it and Ctrl+wheel zooms the UI again.
-7. Ctrl+, → **Display → UI zoom** slider live-applies; the Shortcuts list shows the new Ctrl+= / Ctrl+- / Ctrl+0 rows.
-8. Set 150%, quit fully (tray → Quit), relaunch → still 150%, no badge flash on startup.
-9. **The important isolation check:** at 150%, (a) open a sticky note — it should render at normal 100% size; (b) Ctrl+Shift+S a region — the saved screenshot must crop EXACTLY the rectangle you dragged.
-10. Switch a few themes at 150% — zoom should persist. (Cyberpunk at 130–150% was the whole point — see if it reads comfortably now.)
-
-## When you're happy
-Say the word and I'll push and open the PRs (#54 first, then #56 rebased on it), then start #55 (v0.3.0 release). If anything misbehaves, give me the step number and what you saw.
-
----
-
-Still on hold by user choice: #43 code signing — workflow wiring merged and dormant; `docs/SIGNING.md` has the one-time Azure setup (paperhurts-scoped). The Azure identity-verification step is the long pole — start it first.
+## Local state
+- Repo is on `main`, synced. If your dev server is still running it's now serving main — restart before the next dev session anyway.
+- Your icon candidates (`tasks/.user-logo-options/`) and screenshots (`tasks/.user-screenshots/`) are gitignored and untouched.


### PR DESCRIPTION
PROJECT_STATUS + task scratchpads updated for the v0.3.0 release session (icon/zoom/follow merged, tag pushed, release run in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)