### PR TITLE
Release CI fixes: Ubuntu 24.04 + macOS 10.15 deployment target (#55)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,17 @@ jobs:
             args: ""
           - platform: macos-latest
             args: "--target universal-apple-darwin"
-          - platform: ubuntu-22.04
+          # 24.04, not 22.04: xcap's pipewire bindings (libspa) need a newer
+          # libpipewire than 22.04 ships (v0.3.0 release lesson). Trade-off:
+          # Linux artifacts require glibc >= 2.39 (distros from ~2024).
+          - platform: ubuntu-24.04
             args: ""
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libpipewire-0.3-dev libgbm-dev libegl1-mesa-dev libwayland-dev
@@ -110,6 +113,10 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # whisper.cpp's ggml uses std::filesystem (macOS 10.15+); Tauri also
+          # derives this from bundle.macOS.minimumSystemVersion — set both so
+          # the cmake build and the .app metadata can't drift apart.
+          MACOSX_DEPLOYMENT_TARGET: "10.15"
           # Windows signing (trusted-signing-cli reads these; empty = unused)
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 
 ### Infrastructure
 - Whisper toolchain in CI/release (CMake + libclang); `transcription` is a default-on cargo feature with mobile/feature-off stubs.
-- Linux builds gained xcap/pipewire link deps (`libpipewire-0.3-dev`, `libgbm-dev`, `libegl1-mesa-dev`, `libwayland-dev`).
+- Linux builds gained xcap/pipewire link deps (`libpipewire-0.3-dev`, `libgbm-dev`, `libegl1-mesa-dev`, `libwayland-dev`); release artifacts are now built on Ubuntu 24.04 (glibc ≥ 2.39 required — distros from ~2024).
+- macOS minimum system version is now 10.15 Catalina (whisper.cpp requires `std::filesystem`).
 - Test suite: 132 Vitest + 29 cargo tests.
 
 ## v0.2.0 — 2026-07-18

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
The v0.3.0 tag build failed on all three legs (run 31632127527):
- ubuntu-22.04: libspa (pipewire bindings via xcap) will not compile against 22.04 pipewire 0.3.48 - CI is green because it runs ubuntu-latest (24.04). Release now builds on 24.04 (Linux artifacts require glibc >= 2.39).
- macOS: whisper.cpp ggml uses std::filesystem, unavailable below 10.15; deployment target was Tauri default 10.13. Set bundle.macOS.minimumSystemVersion = 10.15 + explicit MACOSX_DEPLOYMENT_TARGET in the workflow.
- Windows: transient WiX toolset download disconnect (app itself compiled + bundled fine locally) - rerun-only.

After merge: delete draft release + v0.3.0 tag, re-tag on the fixed main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)