### PR TITLE
Docs: v0.3.0 published, session wrap-up

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,7 +1,7 @@
 # Project Status
 
 **Last updated**: 2026-08-12
-**Release**: v0.3.0 tagged (release workflow running as of this update — first tag build with whisper.cpp + xcap; draft release needs review + Publish when it finishes; downloads page then updates itself)
+**Release**: v0.3.0 **PUBLISHED** 2026-08-12 (7 artifacts, all platforms, unsigned — #43 on hold). Took 3 tag attempts; release CI hardened: ubuntu-24.04 runner (libspa needs newer pipewire than 22.04; Linux artifacts need glibc ≥ 2.39), macOS 10.15 deployment target (whisper std::filesystem), Apple signing env gated on non-empty credentials (empty GitHub secret = empty env var = tauri-cli tries to sign). Windows attempt-1 failure was only a transient WiX download.
 
 ## Current State
 Phases 1-9 complete; Phase 10 (Plugin System) not started. v0.2.0 shipped the July 2026 wave (user-tested 2026-07-18):

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,12 +1,14 @@
 # Session scratchpad
 
-## Current: v0.3.0 release workflow running
+## v0.3.0 SHIPPED 2026-08-12 — session complete
 
-- #54/#56/#59 merged (PRs #60/#61/#62), #63 = version bump. Tag v0.3.0 pushed 2026-08-12 ~15:20 EDT.
-- Release run 31632127527 — FIRST tag build with whisper.cpp + xcap on Linux/macOS legs.
-  Windows leg de-risked by a successful local `npm run tauri build` (MSI + NSIS produced).
-- When it finishes: review the DRAFT release on GitHub (artifacts + notes), Publish, close #55.
-  Downloads page self-updates after publish — do NOT redeploy it.
-- If a leg fails: likely missing system dep on the runner; fix in release.yml, delete+re-push tag.
+Published: https://github.com/paperhurts/doc-md/releases/tag/v0.3.0
+Closed this session: #54 (icon), #55 (release), #56 (zoom), #59 (follow).
+Filed: #57 (per-theme font scale), #58 (sticky theme persistence).
 
-Backlog next: #57 per-theme font scale, #58 sticky theme persistence, #43 signing (on hold), #46 a11y, #21 sync.
+Next session candidates (user's pick):
+- #57 per-theme font scale — mechanism sketched in the issue, ~15 min
+- #58 sticky themes restart-proof
+- #43 signing (needs user's Azure setup first — long pole is identity verification)
+- #46 accessibility audit
+- #21 git sync (big)

--- a/tasks/user.md
+++ b/tasks/user.md
@@ -1,16 +1,14 @@
-# Handoff: v0.3.0 releasing
+# v0.3.0 is live 🎉
 
-Everything you tested today is merged and released to main: app icon (#54), UI zoom (#56), transcript follow (#59). Tag `v0.3.0` is pushed and the release workflow is building installers for Windows/macOS/Linux — the first release build that compiles whisper.cpp and xcap on all three platforms.
+https://github.com/paperhurts/doc-md/releases/tag/v0.3.0 — published 2026-08-12. The downloads page (https://paperhurts.github.io/doc-md/) serves it automatically.
 
-## What's left (mostly me, watching CI)
-1. Release run finishes → I review the draft release → you (or I, say the word) click **Publish**.
-2. After publish, https://paperhurts.github.io/doc-md/ shows v0.3.0 automatically — no redeploy.
-3. Installers are still unsigned (#43 on hold) — SmartScreen will warn on first install, as with v0.2.0.
+## If you want it installed
+Grab `doc-md_0.3.0_x64-setup.exe` (or the .msi) from the downloads page and install over v0.2.0. SmartScreen will warn (unsigned, #43 on hold) — "More info → Run anyway". Your vault/notes are untouched. Your Start-menu shortcut gets the new MD icon and everything you tested today: capture, transcription + follow mode, UI zoom, sticky themes.
 
-## For you, once published
-- Install v0.3.0 over your v0.2.0 desktop install — your Start-menu shortcut finally gets the new MD icon and all the capture/zoom/follow features outside the dev tree.
-- Your vault/notes are untouched by upgrades (they're just files in your repo).
+## Repo state
+- `main` synced, all feature branches deleted, issues #54/#55/#56/#59 closed.
+- Release CI got hardened over 3 attempts (details in PROJECT_STATUS.md) — future tags should build clean on the first try.
+- Note for the future: Linux artifacts now need glibc ≥ 2.39 (built on Ubuntu 24.04) and macOS needs 10.15 Catalina+.
 
-## Local state
-- Repo is on `main`, synced. If your dev server is still running it's now serving main — restart before the next dev session anyway.
-- Your icon candidates (`tasks/.user-logo-options/`) and screenshots (`tasks/.user-screenshots/`) are gitignored and untouched.
+## On deck (say which, any time)
+#57 per-theme font sizes (quick) · #58 sticky themes surviving restarts · #43 signing (blocked on your Azure setup) · #46 a11y audit · #21 git sync


### PR DESCRIPTION
PROJECT_STATUS release line updated to published state with the release-CI lessons; task scratchpads reset for next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)